### PR TITLE
Enable job parsing from URL or PDF

### DIFF
--- a/backend/executors/interviewer_runtime.py
+++ b/backend/executors/interviewer_runtime.py
@@ -9,7 +9,7 @@ async def ask_interviewer(
 ) -> dict[str, Any]:
     result = await graph.ainvoke({
         "messages": history,
-        "job_context": job_context
+        "job_input": job_context
     })
     return {
         "text": result["text"],

--- a/backend/routers/chat_ws.py
+++ b/backend/routers/chat_ws.py
@@ -3,6 +3,7 @@ import logging, traceback
 
 from backend.agents.interviewer_graph import graph
 from backend.services.tts_eleven import tts
+from backend.utils.job_loader import load_job_from_url, load_job_from_pdf
 from langchain.memory import ConversationBufferMemory
 from langchain.schema import HumanMessage, AIMessage
 from backend.executors.interviewer_runtime import ask_interviewer
@@ -22,11 +23,33 @@ async def chat_socket(ws: WebSocket):
             msg_type = payload.get("type")
 
             if msg_type == "job_context":
-                # Store the job ad text or URL content
-                job_context = payload.get("data", "")
-                logger.info(f"Received job context: {job_context[:80]}...")
+                # Payload may contain raw text or a URL to fetch
+                if url := payload.get("url"):
+                    try:
+                        job_context = await load_job_from_url(url)
+                        logger.info(f"Loaded job from URL: {url}")
+                    except Exception as e:
+                        await ws.send_json({"type": "error", "data": f"Failed to load URL: {e}"})
+                        continue
+                else:
+                    job_context = payload.get("data", "")
+                    logger.info(f"Received job context text: {job_context[:80]}...")
+
                 await ws.send_json({"type": "ack", "data": "Job context received."})
                 continue  # Wait for next input
+
+            elif msg_type == "job_context_pdf":
+                base64_content = payload.get("content")
+                if not base64_content:
+                    await ws.send_json({"type": "error", "data": "Missing PDF content"})
+                    continue
+                try:
+                    job_context = await load_job_from_pdf(base64_content)
+                    logger.info("Loaded job from PDF")
+                    await ws.send_json({"type": "ack", "data": "Job PDF received."})
+                except Exception as e:
+                    await ws.send_json({"type": "error", "data": f"Failed to read PDF: {e}"})
+                continue
 
             elif msg_type == "user_message":
                 user_text: str = payload.get("text", "")

--- a/backend/utils/job_loader.py
+++ b/backend/utils/job_loader.py
@@ -1,0 +1,25 @@
+import base64
+import io
+import httpx
+from bs4 import BeautifulSoup
+from PyPDF2 import PdfReader
+
+async def load_job_from_url(url: str) -> str:
+    """Fetch and extract text from the given URL."""
+    async with httpx.AsyncClient(timeout=30) as client:
+        r = await client.get(url)
+        r.raise_for_status()
+        html = r.text
+    soup = BeautifulSoup(html, "html.parser")
+    text = soup.get_text(separator=" ", strip=True)
+    return text
+
+async def load_job_from_pdf(base64_content: str) -> str:
+    """Decode base64 PDF content and extract its text."""
+    data = base64.b64decode(base64_content)
+    reader = PdfReader(io.BytesIO(data))
+    pages_text = []
+    for page in reader.pages:
+        pages_text.append(page.extract_text() or "")
+    return "\n".join(pages_text)
+


### PR DESCRIPTION
## Summary
- add `job_loader` helper to fetch job ads from URLs or PDF uploads
- support new `job_context_pdf` message type in websocket router
- pass parsed job text to interviewer runtime via `job_input`

## Testing
- `python -m py_compile backend/routers/chat_ws.py backend/executors/interviewer_runtime.py backend/utils/job_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850984030cc8326a1afdc7a55e0e308