### PR TITLE
Translate LLM prompts to German

### DIFF
--- a/backend/agents/interviewer.py
+++ b/backend/agents/interviewer.py
@@ -9,20 +9,20 @@ from backend.tools.self_critique import SelfCritiqueTool # for rewriting prompts
 # from langchain_community.tools import DuckDuckGoSearchRun
 
 SYSTEM_PROMPT = """
-    You are **Mark**, a rigorous, no-nonsense technical interviewer.
-    Your job each turn:
+    Du bist **Mark**, ein strenger, sachlicher Technik-Interviewer.
+    Deine Aufgabe in jeder Runde:
 
-    1. Evaluate the candidate’s last answer against these criteria:
-    • relevance      • depth     • professionalism
-    2. If the answer is **weak or incomplete**, briefly say why
-    and ask a probing follow-up question.
-    3. If the answer is **adequate**, acknowledge and move to the next topic.
-    4. Never rewrite the candidate’s words; always speak as the interviewer.
+    1. Beurteile die letzte Antwort des Kandidaten nach diesen Kriterien:
+    • Relevanz      • Tiefe     • Professionalität
+    2. Ist die Antwort **schwach oder unvollständig**, erkläre kurz warum
+    und stelle eine nachbohrende Folgefrage.
+    3. Ist die Antwort **ausreichend**, bestätige dies und gehe zum nächsten Thema über.
+    4. Schreibe niemals die Worte des Kandidaten um; sprich immer als Interviewer.
     Format:
-    Interviewer: <your single concise sentence or two>
+    Interviewer: <dein ein- oder zweisätziger Beitrag>
 """
 
-GREETINGS = {"hi", "hello", "hey", "good morning"}
+GREETINGS = {"hi", "hello", "hey", "good morning", "hallo", "guten morgen"}
 
 TOOLS = []
 
@@ -41,7 +41,7 @@ agent = initialize_agent(
 
 async def ask_interviewer(user_text: str) -> str:
     if user_text.lower().strip() in GREETINGS:
-        return "Interviewer: Good morning. Let’s begin. Describe your most relevant experience."  # needs to be dynamic
+        return "Interviewer: Guten Morgen. Lassen Sie uns beginnen. Beschreiben Sie Ihre relevanteste Erfahrung."  # needs to be dynamic
     
     ai_msg = await agent.ainvoke({"input": user_text})
     

--- a/backend/agents/nodes/analyze_job.py
+++ b/backend/agents/nodes/analyze_job.py
@@ -3,11 +3,11 @@ from langchain.schema import SystemMessage
 from backend.services.llm_groq import llm
 
 SYSTEM_PROMPT = """
-You're a helpful assistant for analyzing job vacancies.
+Du bist ein hilfreicher Assistent zur Analyse von Stellenanzeigen.
 
-Extract role, required skills, and a short summary from this job post.
+Extrahiere Rolle, erforderliche Fähigkeiten und eine kurze Zusammenfassung aus dieser Stellenbeschreibung.
 
-Respond in this JSON format:
+Antworte in diesem JSON-Format:
 {
   "job_role": "...",
   "required_skills": ["...", "..."],

--- a/backend/agents/nodes/call_model.py
+++ b/backend/agents/nodes/call_model.py
@@ -5,23 +5,23 @@ import json
 def call_model(state: dict) -> dict:
     job_summary = state.get("summary", "a general technical role")
     base_prompt = f"""
-    You are Mark, a strict technical interviewer.
+    Du bist Mark, ein strenger technischer Interviewer.
 
-    The candidate is applying for: {job_summary}
+    Der Kandidat bewirbt sich auf: {job_summary}
 
-    Behavior rules:
-    1. If the candidate says 'hello' or greets you, reply with a short acknowledgment and begin the interview.
-    2. Ask relevant technical questions based on what they say. If they give no information, start with: "Describe your most relevant experience."
-    3. Always reply in this JSON format:
+    Verhaltensregeln:
+    1. Wenn der Kandidat 'hallo' sagt oder dich begrüßt, antworte kurz und beginne das Interview.
+    2. Stelle passende technische Fragen basierend auf seinen Antworten. Wenn er keine Informationen gibt, starte mit: "Beschreiben Sie Ihre relevanteste Erfahrung."
+    3. Antworte immer in diesem JSON-Format:
     {{
     "text": "..."
     }}
-    Prefix the reply text with "Interviewer:".
+    Setze dem Antworttext "Interviewer:" voran.
     """
 
     messages = state["messages"]
     if messages and isinstance(messages[-1], HumanMessage) and messages[-1].content == "///INIT_START///":
-        messages = messages[:-1] + [HumanMessage(content="Let's begin.")]
+        messages = messages[:-1] + [HumanMessage(content="Legen wir los.")]
 
     full_messages = [SystemMessage(content=base_prompt), *messages]
 

--- a/backend/tools/self_critique.py
+++ b/backend/tools/self_critique.py
@@ -11,11 +11,11 @@ class SelfCritiqueTool(BaseTool):
     def _run(self, draft: str) -> str:
         """Run the tool with the given draft reply."""
         prompt = (
-            "You are a strict technical interviewer. "
-            "Check if the following draft reply matches your persona:\n\n"
+            "Du bist ein strenger technischer Interviewer. "
+            "Prüfe, ob die folgende Entwurfsantwort zu deiner Persona passt:\n\n"
             f"{draft}\n\n"
-            "If it does not match, rewrite it to be more strict and professional. "
-            "If it does match, return it unchanged."
+            "Wenn sie nicht passt, schreibe sie strenger und professioneller um. "
+            "Wenn sie passt, gib sie unverändert zurück."
         )
         
         response = llm.invoke(prompt)


### PR DESCRIPTION
## Summary
- translate interviewer prompt to German
- translate job analysis prompt to German
- translate runtime prompt to German
- translate self-critique tool prompt to German
- support German greetings and default reply

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68514140e0708326ad65a40bae7a8d67