### PR TITLE
Improve UI workflow

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,8 +10,8 @@ function App() {
   return (
     <div className="App">
       {!interactionMode && <JobInput onInteractionModeSelect={setInteractionMode} />}
-      {interactionMode === "chat" && <InterviewChat />}
-      {interactionMode === "simulation" && <InterviewSimulation />}
+      {interactionMode === "chat" && <InterviewChat onBack={() => setInteractionMode(null)} />}
+      {interactionMode === "simulation" && <InterviewSimulation onBack={() => setInteractionMode(null)} />}
     </div>
   );
 }

--- a/frontend/src/components/InterviewChat.jsx
+++ b/frontend/src/components/InterviewChat.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import MicRecorder from 'mic-recorder-to-mp3';
 
-function InterviewChat() {
+function InterviewChat({ onBack }) {
     const [message, setMessage] = useState('');
     const [tts, setTts] = useState(false);
     const [log, setLog] = useState([]);
@@ -281,6 +281,11 @@ function InterviewChat() {
 
     return (
         <div>
+            <div style={{ marginBottom: 10 }}>
+                <button onClick={onBack} style={{ padding: '6px 12px', background: '#eee', border: '1px solid #ccc', borderRadius: 4, cursor: 'pointer' }}>
+                    ← Back
+                </button>
+            </div>
             {getStatusIndicator()}
 
             <div

--- a/frontend/src/components/InterviewSimulation.jsx
+++ b/frontend/src/components/InterviewSimulation.jsx
@@ -1,9 +1,28 @@
 import React from 'react';
 
-export default function InterviewSimulation() {
+export default function InterviewSimulation({ onBack }) {
   return (
-    <div style={{ height: '100vh', background: '#222', color: 'white', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-      <h1>Interview Simulation (3D + Voice)</h1>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: '#111', color: 'white' }}>
+      <div style={{ padding: '10px', background: '#333', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span>Interview Simulation</span>
+        <button onClick={onBack} style={{ padding: '6px 12px', background: '#eee', color: '#000', border: 'none', borderRadius: 4, cursor: 'pointer' }}>
+          ← Back
+        </button>
+      </div>
+      <div style={{ flex: 1, display: 'flex' }}>
+        <div style={{ flex: 3, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+          <div style={{ width: '80%', height: '80%', background: '#555', display: 'flex', justifyContent: 'center', alignItems: 'center', borderRadius: 8 }}>
+            <p>Interviewer Video Placeholder</p>
+          </div>
+        </div>
+        <div style={{ flex: 1, padding: '10px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <div style={{ flex: 1, background: '#222', borderRadius: 8, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+            <p>Your Video</p>
+          </div>
+          <button style={{ padding: '8px', background: '#28a745', border: 'none', borderRadius: 4, cursor: 'pointer', color: 'white' }}>Mute</button>
+          <button style={{ padding: '8px', background: '#dc3545', border: 'none', borderRadius: 4, cursor: 'pointer', color: 'white' }}>Leave</button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/JobInput.jsx
+++ b/frontend/src/components/JobInput.jsx
@@ -131,7 +131,7 @@ function JobInput({ onInteractionModeSelect }) {
   useEffect(() => cleanup, [cleanup]);
 
   return (
-    <div style={{ marginBottom: '20px' }}>
+    <div style={{ margin: '40px auto', maxWidth: '600px' }}>
       <h4>Job Posting PDF</h4>
       <p style={{ fontSize: '0.9em', color: '#666' }}>
         💡 Please upload a PDF version of the job posting. On most job platforms, 
@@ -189,7 +189,7 @@ function JobInput({ onInteractionModeSelect }) {
               cursor: 'pointer'
             }}
           >
-            Start Chat
+            Start Interview Chat
           </button>
 
           <button


### PR DESCRIPTION
## Summary
- tweak JobInput and rename button to Start Interview Chat
- add back buttons to Chat and Simulation screens
- create placeholder Teams-like layout for simulation

## Testing
- `npm --prefix frontend test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d876c790832682c52203552caa71