### PR TITLE
Improve call_model JSON parsing

### DIFF
--- a/backend/agents/nodes/call_model.py
+++ b/backend/agents/nodes/call_model.py
@@ -28,16 +28,17 @@ def call_model(state: dict) -> dict:
     response = llm.invoke(full_messages)
     content = response.content if isinstance(response.content, str) else str(response.content)
 
-    try:
-        parsed = json.loads(content)
-        return {
-            **state,
-            "messages": [*messages, response],
-            "text": parsed["text"]
-        }
-    except:
-        return {
-            **state,
-            "messages": [*messages, response],
-            "text": response.content
-        }
+    json_start = content.find("{")
+    parsed_text = None
+    if json_start != -1:
+        try:
+            parsed = json.loads(content[json_start:])
+            parsed_text = parsed["text"]
+        except Exception:
+            parsed_text = None
+
+    return {
+        **state,
+        "messages": [*messages, response],
+        "text": parsed_text if parsed_text is not None else content
+    }

--- a/backend/tests/test_call_model.py
+++ b/backend/tests/test_call_model.py
@@ -1,0 +1,45 @@
+import types
+import sys
+import os
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+# Stub langchain.schema messages
+langchain = types.ModuleType("langchain")
+schema = types.ModuleType("langchain.schema")
+
+class BaseMessage:
+    def __init__(self, content):
+        self.content = content
+
+class HumanMessage(BaseMessage):
+    pass
+
+class SystemMessage(BaseMessage):
+    pass
+
+schema.HumanMessage = HumanMessage
+schema.SystemMessage = SystemMessage
+langchain.schema = schema
+sys.modules['langchain'] = langchain
+sys.modules['langchain.schema'] = schema
+
+# Stub backend.services.llm_groq before importing call_model
+llm_module = types.ModuleType('backend.services.llm_groq')
+class DummyLLM:
+    def __init__(self, content):
+        self._content = content
+    def invoke(self, messages):
+        return types.SimpleNamespace(content=self._content)
+
+llm_module.llm = DummyLLM('Interviewer: { "text": "hi" }')
+sys.modules['backend.services.llm_groq'] = llm_module
+
+from backend.agents.nodes.call_model import call_model
+
+
+def test_parses_json_after_prefix():
+    state = {"messages": []}
+    result = call_model(state)
+    assert result["text"] == "hi"


### PR DESCRIPTION
## Summary
- look for the first `{` in model responses before JSON parsing
- add tests for parsing text embedded in `Interviewer: {...}` strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4e976c848326ba352235bcde4f51