### PR TITLE
Add interviewSimulation call UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,12 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "three": "^0.160.0",
+    "@react-three/fiber": "^8.15.8"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import JobInput from './components/JobInput';
 import InterviewChat from './components/InterviewChat';
+import LegacyInterviewSimulation from './components/LegacyInterviewSimulation';
 import InterviewSimulation from './components/InterviewSimulation';
 import './styles/App.css';
 
@@ -32,9 +33,14 @@ function App() {
         />
       )}
       {interactionMode === "simulation" && (
-        <InterviewSimulation
+        <LegacyInterviewSimulation
           onBack={() => setInteractionMode(null)}
           socket={socket}
+        />
+      )}
+      {interactionMode === "interviewSimulation" && (
+        <InterviewSimulation
+          onEnd={() => setInteractionMode(null)}
         />
       )}
     </div>

--- a/frontend/src/components/InterviewSimulation.jsx
+++ b/frontend/src/components/InterviewSimulation.jsx
@@ -1,27 +1,29 @@
 import React from 'react';
+import { Canvas } from '@react-three/fiber';
 
-export default function InterviewSimulation({ onBack, socket }) {
+export default function InterviewSimulation({ onEnd }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: '#111', color: 'white' }}>
-      <div style={{ padding: '10px', background: '#333', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <span>Interview Simulation</span>
-        <button onClick={onBack} style={{ padding: '6px 12px', background: '#eee', color: '#000', border: 'none', borderRadius: 4, cursor: 'pointer' }}>
-          ← Back
-        </button>
+    <div className="flex flex-col h-screen bg-gray-900 text-white">
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex-1 bg-gray-800">
+          <Canvas className="w-full h-full">
+            {/* 3D interviewer scene goes here */}
+          </Canvas>
+        </div>
+        <div className="w-80 border-l border-gray-700 p-4 overflow-y-auto hidden md:block">
+          <h2 className="text-lg font-semibold mb-2">Transcript</h2>
+          <div id="transcript" className="space-y-1 text-sm">
+            {/* Transcript messages will be inserted here */}
+          </div>
+        </div>
       </div>
-      <div style={{ flex: 1, display: 'flex' }}>
-        <div style={{ flex: 3, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-          <div style={{ width: '80%', height: '80%', background: '#555', display: 'flex', justifyContent: 'center', alignItems: 'center', borderRadius: 8 }}>
-            <p>Interviewer Video Placeholder</p>
-          </div>
-        </div>
-        <div style={{ flex: 1, padding: '10px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
-          <div style={{ flex: 1, background: '#222', borderRadius: 8, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-            <p>Your Video</p>
-          </div>
-          <button style={{ padding: '8px', background: '#28a745', border: 'none', borderRadius: 4, cursor: 'pointer', color: 'white' }}>Mute</button>
-          <button style={{ padding: '8px', background: '#dc3545', border: 'none', borderRadius: 4, cursor: 'pointer', color: 'white' }}>Leave</button>
-        </div>
+      <div className="p-4 bg-gray-800 flex justify-center">
+        <button
+          className="px-4 py-2 bg-red-600 hover:bg-red-700 rounded"
+          onClick={onEnd}
+        >
+          End Call
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/JobInput.jsx
+++ b/frontend/src/components/JobInput.jsx
@@ -204,6 +204,20 @@ function JobInput({ onInteractionModeSelect, socket }) {
           >
             Start Interview Simulation
           </button>
+          <button
+            onClick={() => onInteractionModeSelect("interviewSimulation")}
+            style={{
+              marginLeft: '10px',
+              padding: '8px 16px',
+              backgroundColor: '#0ea5e9',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer'
+            }}
+          >
+            Start Teams Call
+          </button>
         </div>
       )}
     </div>

--- a/frontend/src/components/LegacyInterviewSimulation.jsx
+++ b/frontend/src/components/LegacyInterviewSimulation.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export default function LegacyInterviewSimulation({ onBack, socket }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: '#111', color: 'white' }}>
+      <div style={{ padding: '10px', background: '#333', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span>Interview Simulation</span>
+        <button onClick={onBack} style={{ padding: '6px 12px', background: '#eee', color: '#000', border: 'none', borderRadius: 4, cursor: 'pointer' }}>
+          ← Back
+        </button>
+      </div>
+      <div style={{ flex: 1, display: 'flex' }}>
+        <div style={{ flex: 3, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+          <div style={{ width: '80%', height: '80%', background: '#555', display: 'flex', justifyContent: 'center', alignItems: 'center', borderRadius: 8 }}>
+            <p>Interviewer Video Placeholder</p>
+          </div>
+        </div>
+        <div style={{ flex: 1, padding: '10px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <div style={{ flex: 1, background: '#222', borderRadius: 8, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+            <p>Your Video</p>
+          </div>
+          <button style={{ padding: '8px', background: '#28a745', border: 'none', borderRadius: 4, cursor: 'pointer', color: 'white' }}>Mute</button>
+          <button style={{ padding: '8px', background: '#dc3545', border: 'none', borderRadius: 4, cursor: 'pointer', color: 'white' }}>Leave</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,13 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import './index.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- replace CallSimulation with new InterviewSimulation component
- keep previous video mock as LegacyInterviewSimulation
- wire up interviewSimulation mode in App and JobInput

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a58bdc15483269b8c06b742f89775